### PR TITLE
CloseMessage error is now optional according to signalr protocol spec

### DIFF
--- a/src/Protobuf.Protocol/ProtobufHubProtocol.cs
+++ b/src/Protobuf.Protocol/ProtobufHubProtocol.cs
@@ -184,7 +184,9 @@ namespace Protobuf.Protocol
 
             protobufCloseMessage.MergeFrom(protobufMessage.ToArray());
 
-            return new CloseMessage(protobufCloseMessage.Error);
+            var error = string.IsNullOrEmpty(protobufCloseMessage.Error) ? null : protobufCloseMessage.Error;
+
+            return new CloseMessage(error);
         }
 
         public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
@@ -351,7 +353,7 @@ namespace Protobuf.Protocol
         {
             var protobufCloseMessage = new CloseMessageProtobuf
             {
-                Error = closeMessage.Error
+                Error = closeMessage.Error ?? ""
             };
 
             var packedMessage = MessageDescriptor.PackMessage(HubProtocolConstants.CloseMessageType, protobufCloseMessage.ToByteArray());

--- a/test/Protobuf.Protocol.Tests/CloseMessageTests.cs
+++ b/test/Protobuf.Protocol.Tests/CloseMessageTests.cs
@@ -12,6 +12,27 @@ namespace Protobuf.Protocol.Tests
 {
     public class CloseMessageTests
     {
+        [Fact]
+        public void Protocol_Should_Handle_CancelInvocationMessage_Without_Error()
+        {
+            var logger = NullLogger<ProtobufHubProtocol>.Instance;
+            var binder = new Mock<IInvocationBinder>();
+            var protobufType = Array.Empty<Type>();
+
+            var protobufHubProtocol = new ProtobufHubProtocol(protobufType, logger);
+            var writer = new ArrayBufferWriter<byte>();
+            var closeMessage = new CloseMessage(null);
+
+            protobufHubProtocol.WriteMessage(closeMessage, writer);
+            var encodedMessage = new ReadOnlySequence<byte>(writer.WrittenSpan.ToArray());
+            var result = protobufHubProtocol.TryParseMessage(ref encodedMessage, binder.Object, out var resultCloseMessage);
+
+            Assert.True(result);
+            Assert.NotNull(resultCloseMessage);
+            Assert.IsType<CloseMessage>(resultCloseMessage);
+            Assert.Null(((CloseMessage)resultCloseMessage).Error);
+        }
+
         [Theory]
         [InlineData("Some Error")]
         [InlineData("Some bad stuff happened")]


### PR DESCRIPTION
Fix for #2 